### PR TITLE
Sdonela/disable examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,8 @@ project(zlib C)
 
 set(VERSION "1.3.0.1")
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-  set(ZLIB_BUNDLED OFF)
-else()
-  set(ZLIB_BUNDLED ON)
-endif()
-
 option(ZLIB_BUILD_EXAMPLES
-  "Should Zlib build its examples." ${ZLIB_BUNDLED})
+  "Should Zlib build its examples." ON)
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(zlib C)
 set(VERSION "1.3.0.1")
 
 option(ZLIB_BUILD_EXAMPLES
-  "Should Zlib build its examples." ON)
+  "If ON, Zlib will build its examples." ON)
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ project(zlib C)
 
 set(VERSION "1.3.0.1")
 
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  set(ZLIB_BUNDLED OFF)
+else()
+  set(ZLIB_BUNDLED ON)
+endif()
+
+option(ZLIB_BUILD_EXAMPLES
+  "Should Zlib build its examples." ${ZLIB_BUNDLED})
+
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
 set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
@@ -190,24 +199,26 @@ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
 endif()
 
-#============================================================================
-# Example binaries
-#============================================================================
-
-add_executable(example test/example.c)
-target_link_libraries(example zlib)
-add_test(example example)
-
-add_executable(minigzip test/minigzip.c)
-target_link_libraries(minigzip zlib)
-
-if(HAVE_OFF64_T)
-    add_executable(example64 test/example.c)
-    target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
-
-    add_executable(minigzip64 test/minigzip.c)
-    target_link_libraries(minigzip64 zlib)
-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+if(ZLIB_BUILD_EXAMPLES)
+    #============================================================================
+    # Example binaries
+    #============================================================================
+    
+    add_executable(example test/example.c)
+    target_link_libraries(example zlib)
+    add_test(example example)
+    
+    add_executable(minigzip test/minigzip.c)
+    target_link_libraries(minigzip zlib)
+    
+    if(HAVE_OFF64_T)
+        add_executable(example64 test/example.c)
+        target_link_libraries(example64 zlib)
+        set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+        add_test(example64 example64)
+    
+        add_executable(minigzip64 test/minigzip.c)
+        target_link_libraries(minigzip64 zlib)
+        set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+    endif()
 endif()


### PR DESCRIPTION
Upstream copy of zlib provides no way to disable the examples when building.  The issue was noticed by others and is documented in issue [147](https://github.com/madler/zlib/issues/147) upstream.  However, the proposed upstream solution is naïve.  This provides a more complete way to disable them through an option.